### PR TITLE
Fix async package at 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     }
   ],
   "dependencies": {
-    "async": "*"
+    "async": "1.5.2"
   },
   "devDependencies": {
     "optimist": "*"


### PR DESCRIPTION
To avoid breaking change to `async.whilst`. In 1.5.2 and earlier, the first function of `async.whilst` returns `true` while the second function is to be called, but in later version of `async` the function itself takes a callback as argument and calls it to determine whether to continue to the second function.